### PR TITLE
Ac/RouteAwareTabs

### DIFF
--- a/src/shared/components/ui/nav-bar/nav-bar.emotion.ts
+++ b/src/shared/components/ui/nav-bar/nav-bar.emotion.ts
@@ -1,0 +1,17 @@
+import styled from 'react-emotion';
+import { themePadding } from 'shared/styling/utils';
+
+export const NavBarContainer = styled('div')`
+  display: flex;
+`;
+
+export const NavContainerTab = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`;
+
+export const NavItemTab = styled('div')`
+  ${themePadding({ all: 3 })};
+`;

--- a/src/shared/components/ui/nav-bar/nav-bar.tsx
+++ b/src/shared/components/ui/nav-bar/nav-bar.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { RoutedTabs } from 'shared/routing/route-tabs';
+import { UiStore } from 'shared/stores/ui-store';
+import { IRouterLayout } from 'shared/types/routing';
+import { connectStores } from 'shared/utils/store-utils';
+import { NavContainer } from './nav-container';
+import { NavItem } from './nav-item';
+
+interface INavBarConnectedProps extends IRouterLayout {
+  queueToast: UiStore['queueToast'];
+}
+
+class NavBar extends React.Component<IRouterLayout> {
+  get connectedProps() {
+    return this.props as INavBarConnectedProps;
+  }
+
+  onFailure = (text: string) => {
+    const { queueToast } = this.connectedProps;
+
+    queueToast({ text });
+  };
+
+  render() {
+    const { navItems } = this.props;
+
+    return (
+      <RoutedTabs
+        navItems={navItems}
+        onFailure={this.onFailure}
+        tabContainer={NavContainer}
+        tabItem={NavItem}
+      />
+    );
+  }
+}
+
+const WrappedNavBar = connectStores(({ uiStore: { queueToast } }) => ({
+  queueToast
+}))(NavBar);
+
+export { WrappedNavBar as NavBar };

--- a/src/shared/components/ui/nav-bar/nav-container.tsx
+++ b/src/shared/components/ui/nav-bar/nav-container.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { ITabContainer } from 'shared/types/routing';
+import { NavContainerTab } from './nav-bar.emotion';
+
+export class NavContainer extends React.Component<ITabContainer> {
+  get children() {
+    const { children } = this.props;
+
+    if (!Array.isArray(children)) {
+      return children;
+    }
+
+    return children.map((child: any, index: number) => {
+      if (!child.type || child.type.name !== 'NavItem') {
+        return child;
+      }
+
+      return <div onClick={this.clickHandler.bind(this, index)}>{child}</div>;
+    });
+  }
+
+  clickHandler = (index: number, evt: any) => {
+    const { onChange } = this.props;
+
+    onChange(evt, index);
+  };
+
+  render() {
+    return <NavContainerTab>{this.children}</NavContainerTab>;
+  }
+}

--- a/src/shared/components/ui/nav-bar/nav-item.tsx
+++ b/src/shared/components/ui/nav-bar/nav-item.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { ITabItem } from 'shared/types/routing';
+import { NavItemTab } from './nav-bar.emotion';
+
+export class NavItem extends React.Component<ITabItem> {
+  render() {
+    const { label } = this.props;
+    return <NavItemTab>{label}</NavItemTab>;
+  }
+}

--- a/src/shared/layouts/app/app-layout.tsx
+++ b/src/shared/layouts/app/app-layout.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { Toasts } from 'shared/components/ui/toasts';
+import { LoginLayout } from 'shared/layouts/login';
 import { MainLayout } from 'shared/layouts/main';
 import { RouteManager } from 'shared/routing';
 import { IToast } from 'shared/stores/ui-store';
@@ -24,7 +25,7 @@ const AppLayout: React.SFC<IAppLayoutProps> = props => {
       <RouteManager
         isLoggedIn={isLoggedIn}
         privateLayout={MainLayout}
-        publicLayout={MainLayout}
+        publicLayout={LoginLayout}
         setStatus={setStatus}
       />
       <Toasts />

--- a/src/shared/layouts/login/index.ts
+++ b/src/shared/layouts/login/index.ts
@@ -1,0 +1,1 @@
+export * from './login-layout';

--- a/src/shared/layouts/login/login-layout.emotion.ts
+++ b/src/shared/layouts/login/login-layout.emotion.ts
@@ -1,0 +1,15 @@
+import styled from 'react-emotion';
+import { Palette } from 'shared/styling/variables';
+
+export const LoginLayoutContainer = styled('div')`
+  background-color: ${Palette.Grey.DD};
+  background-position: center;
+  background-repeat: no-repeat;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/shared/layouts/login/login-layout.tsx
+++ b/src/shared/layouts/login/login-layout.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { IRouterLayout } from 'shared/types/routing';
+import { LoginLayoutContainer } from './login-layout.emotion';
+
+export class LoginLayout extends React.Component<IRouterLayout> {
+  render() {
+    const { children } = this.props;
+
+    return <LoginLayoutContainer>{children}</LoginLayoutContainer>;
+  }
+}

--- a/src/shared/layouts/main/main-layout.tsx
+++ b/src/shared/layouts/main/main-layout.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { IRouterLayout } from 'shared/types/routing';
 import { MainLayoutContainer } from './main-layout.emotion';
 
-export class MainLayout extends React.Component {
+export class MainLayout extends React.Component<IRouterLayout> {
   render() {
     const { children } = this.props;
 

--- a/src/shared/layouts/main/main-layout.tsx
+++ b/src/shared/layouts/main/main-layout.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
+import { NavBar } from 'shared/components/ui/nav-bar/nav-bar';
 import { IRouterLayout } from 'shared/types/routing';
 import { MainLayoutContainer } from './main-layout.emotion';
 
 export class MainLayout extends React.Component<IRouterLayout> {
   render() {
-    const { children } = this.props;
+    const { children, navItems } = this.props;
 
-    return <MainLayoutContainer>{children}</MainLayoutContainer>;
+    return (
+      <MainLayoutContainer>
+        <NavBar navItems={navItems} />
+        {children}
+      </MainLayoutContainer>
+    );
   }
 }

--- a/src/shared/pages/about/about.tsx
+++ b/src/shared/pages/about/about.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { PageContainer } from 'shared/styling/components/page.emotion';
+
+export const AboutPage: React.SFC = () => (
+  <PageContainer>
+    <h1>About</h1>
+    <p>
+      This page servers to describe this web-starter!
+      <br />
+      <em># TODO: Add information to this page</em>
+    </p>
+  </PageContainer>
+);

--- a/src/shared/pages/about/index.ts
+++ b/src/shared/pages/about/index.ts
@@ -1,0 +1,1 @@
+export * from './about';

--- a/src/shared/pages/login/login-page.tsx
+++ b/src/shared/pages/login/login-page.tsx
@@ -19,7 +19,7 @@ interface ILoginPageState {
   password: string;
 }
 
-class LoginPage extends React.Component<RouteComponentProps> {
+class LoginPage extends React.Component {
   state: ILoginPageState = {
     password: '',
     username: ''

--- a/src/shared/routing/private-routes.ts
+++ b/src/shared/routing/private-routes.ts
@@ -1,3 +1,4 @@
+import { AboutPage } from 'shared/pages/about';
 import { DashboardPage } from 'shared/pages/dashboard';
 import { IRoute } from 'shared/types/routing';
 
@@ -7,6 +8,13 @@ export const PrivateRoutes = (): IRoute[] => [
   {
     component: DashboardPage,
     exact: true,
+    name: 'Dashboard',
     path: IndexRoute
+  },
+  {
+    component: AboutPage,
+    exact: true,
+    name: 'About',
+    path: '/about'
   }
 ];

--- a/src/shared/routing/route-tabs.tsx
+++ b/src/shared/routing/route-tabs.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { IRouterLayout, ITabContainer, ITabItem } from 'shared/types/routing';
+
+interface IRoutedTabsProps extends IRouterLayout {
+  tabContainer: React.ComponentType<ITabContainer>;
+  tabItem: React.ComponentType<ITabItem>;
+  onFailure: (reason: string) => void;
+}
+
+interface IRoutedTabsExtendedProps
+  extends IRoutedTabsProps,
+    RouteComponentProps {}
+
+interface IRoutedTabsState {
+  value: number;
+}
+
+class RoutedTabs extends React.Component<
+  IRoutedTabsExtendedProps,
+  IRoutedTabsState
+> {
+  constructor(props: IRoutedTabsExtendedProps, context: any) {
+    super(props, context);
+
+    this.state = { value: this.extractIndex(props) };
+  }
+
+  extractIndex = ({ navItems }: IRoutedTabsExtendedProps) => {
+    const index = navItems.findIndex(({ isCurrent }) => !!isCurrent);
+    return index >= 0 ? index : 0;
+  };
+
+  handleChange = (_: any, value: number) => {
+    this.setState({ value }, this.onTabChange);
+  };
+
+  onTabChange = () => {
+    const { history, navItems, onFailure } = this.props;
+    const { value } = this.state;
+
+    const route = navItems[value];
+
+    if (route) {
+      history.push(route.path);
+    } else {
+      onFailure('Error navigating to selected tab');
+    }
+  };
+
+  render() {
+    const { tabItem: TabItem, tabContainer: TabContainer } = this.props;
+
+    return (
+      <TabContainer onChange={this.handleChange} value={this.state.value}>
+        {this.props.navItems.map(({ disabled, icon, name, path }) => (
+          <TabItem key={path} disabled={disabled} icon={icon} label={name} />
+        ))}
+      </TabContainer>
+    );
+  }
+}
+
+const WrappedRoutedTabs = withRouter(RoutedTabs);
+
+export { WrappedRoutedTabs as RoutedTabs };

--- a/src/shared/types/routing.ts
+++ b/src/shared/types/routing.ts
@@ -1,5 +1,19 @@
+import { Omit } from 'react-router';
+
 export interface IRoute {
   component: React.ComponentType;
+  disabled?: boolean;
+  icon?: React.ReactElement;
   exact?: boolean;
+  name?: string;
   path: string;
 }
+
+export interface INav extends Omit<IRoute, 'component'> {
+  isCurrent?: boolean;
+}
+
+export interface IRouterLayout {
+  navItems: INav[];
+}
+

--- a/src/shared/types/routing.ts
+++ b/src/shared/types/routing.ts
@@ -17,3 +17,13 @@ export interface IRouterLayout {
   navItems: INav[];
 }
 
+export interface ITabContainer {
+  onChange: (event: React.ChangeEvent<{}>, value: any) => void;
+  value: any;
+}
+
+export interface ITabItem {
+  disabled?: boolean;
+  icon?: React.ReactNode;
+  label?: React.ReactNode;
+}

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,6 @@
     "tslint-config-prettier"
   ],
   "rules": {
-    "array-type": [true, "generic"],
     "import-name": [
       true,
       {


### PR DESCRIPTION
Added some Route Awareness to Route Layouts. This will enable a user to navigate through tabs, without needing to re-render the layout each time. The tabs have some awareness of the current route though do not belong to that route itself. The Tab Container and Tab Items are modelled to work with `@material-ui` but this starter pack does not have an intention to actually have a dependency on material ui.